### PR TITLE
Add granular loading

### DIFF
--- a/packages/react/src/hooks/useProfile.ts
+++ b/packages/react/src/hooks/useProfile.ts
@@ -36,7 +36,7 @@ export const useProfile = (
   const [isLoading, setIsLoading] = useState(true);
 
   // Individual loading
-  const [isNip05Loading, setIsNip05Loading] = useState(true);
+  const [isNip05Loading, setIsNip05Loading] = useState(false);
   const [isLud16Loading, setIsLud16Loading] = useState(true);
 
   // Data
@@ -62,6 +62,7 @@ export const useProfile = (
       return;
     }
 
+    setIsNip05Loading(true);
     resolveNip05(walias).then((pubkey) => {
       if (!pubkey) {
         setIsNip05Loading(false);

--- a/packages/react/src/hooks/useProfile.ts
+++ b/packages/react/src/hooks/useProfile.ts
@@ -21,6 +21,9 @@ export interface UseProfileReturns {
   nip05Avatar?: string;
   domainAvatar: string;
   isLoading: boolean;
+  isNip05Loading: boolean;
+  isLud16Loading: boolean;
+  isDomainAvatarLoading: boolean;
 }
 
 export const useProfile = (
@@ -125,6 +128,9 @@ export const useProfile = (
     nip05Avatar,
     lud16Avatar,
     domainAvatar,
+    isNip05Loading,
+    isLud16Loading,
+    isDomainAvatarLoading,
   };
 };
 

--- a/packages/react/src/hooks/useProfile.ts
+++ b/packages/react/src/hooks/useProfile.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNostrContext } from '../context/NostrContext.js';
 import { NIP05_REGEX, queryProfile } from 'nostr-tools/nip05';
 import type { NDKUserProfile } from '@nostr-dev-kit/ndk';

--- a/packages/react/src/hooks/useProfile.ts
+++ b/packages/react/src/hooks/useProfile.ts
@@ -25,7 +25,7 @@ export interface UseProfileReturns {
 
 export const useProfile = (
   { walias, pubkey: _pubkey }: UseProfileParams,
-  options?: UseProfileConfig,
+  _options?: UseProfileConfig,
 ): UseProfileReturns => {
   // Hooks
   const { ndk } = useNostrContext({});


### PR DESCRIPTION
Add granular loading for `useProfile` hook so that the user may know whether the NIP-05, LUD-16, or Domain Avatar is loading